### PR TITLE
fix Synopsis

### DIFF
--- a/lib/Kafka.pm
+++ b/lib/Kafka.pm
@@ -106,6 +106,8 @@ use Const::Fast;
         $BITS64
     );
     use Kafka::Connection;
+    use Kafka::Producer;
+    use Kafka::Consumer;
 
     # A simple example of Kafka usage
 


### PR DESCRIPTION
one needs to use Kafka::Consumer and Kafka::Producer to get rid of these error messages.

 perl test.pl
This is Kafka package 0.8011
You have a 64 bit system
Can't locate object method "new" via package "Kafka::Consumer" (perhaps you forgot to load "Kafka::Consumer"?) at test.
pl line 16.