### PR TITLE
Use inet_aton for IPv4

### DIFF
--- a/lib/Kafka/IO.pm
+++ b/lib/Kafka/IO.pm
@@ -52,6 +52,7 @@ use Socket qw(
     SO_RCVTIMEO
     SO_SNDTIMEO
     inet_pton
+    inet_aton
     inet_ntop
     pack_sockaddr_in
     pack_sockaddr_in6
@@ -427,7 +428,7 @@ sub _connect {
 
     # Connect returns immediately because of O_NONBLOCK.
     my $sockaddr = $self->{af} eq AF_INET
-        ? pack_sockaddr_in(  $port, inet_pton( $self->{af}, $ip ) )
+        ? pack_sockaddr_in(  $port, inet_aton( $ip ) )
         : pack_sockaddr_in6( $port, inet_pton( $self->{af}, $ip ) )
     ;
     connect( $connection, $sockaddr ) || $!{EINPROGRESS} || die( "connect ip = $ip, port = $port: $!\n" );


### PR DESCRIPTION
First, thanks for this module.

Now, when IPv6 was added seems that it broke something. I'm still trying to figure out what could be but so far it seems to fall into the use of inet_pton for IPv4 addresses.

True, the documentation of Socket indicates that pton is suggested and aton is there only for legacy reasons however I'm not able to get any connection to an IPv4 host with pton. The fix is easy (check diff), I ran the tests (make tests) and all of them passed.

So far I'm able to replicate this with a very simple perl script:

use strict;
use warnings;
use 5.010;

use Socket qw(inet_aton inet_pton AF_INET sockaddr_in pack_sockaddr_in unpack_sockaddr_in);

my ($host) = shift @ARGV;
my $port = 9999;

print "$host\n";
my ($v4) = inet_pton(AF_INET, $host);
pack_sockaddr_in($port, $v4);

$ ./test.pl 127.0.0.1
127.0.0.1
Bad arg length for Socket::pack_sockaddr_in, length is 16, should be 4 at ./test.pl line 19.

I tried to find any other life examples of pack_sockaddr_in with pton but couldn't find a single one.

In the interim, would you mind creating a bug-fix version that for IPv4 it uses aton? (fwiw I tested IPV6 and IPV6 works great with pton).