### PR TITLE
Remove unnecessary dependency on List::MoreUtils

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,6 @@ my %config = (
         'Exporter'                  => '5.70',
         'IO::Compress::Gzip'        => '2.064',
         'IO::Uncompress::Gunzip'    => '2.064',
-        'List::MoreUtils'           => '0.33',
         'List::Util'                => '1.38',
         'Params::Util'              => '1.07',
         'Scalar::Util'              => '1.38',

--- a/README
+++ b/README
@@ -39,7 +39,6 @@ Kafka:
    Exporter
    IO::Compress::Gzip
    IO::Uncompress::Gunzip
-   List::MoreUtils
    List::Util
    Params::Util
    Scalar::Util

--- a/lib/Kafka.pm
+++ b/lib/Kafka.pm
@@ -1321,7 +1321,6 @@ Kafka:
     Data::Validate::Domain
     Data::Validate::IP
     Exception::Class
-    List::MoreUtils
     Params::Util
     Scalar::Util::Numeric
     String::CRC32

--- a/lib/Kafka/Connection.pm
+++ b/lib/Kafka/Connection.pm
@@ -40,10 +40,8 @@ use Data::Validate::IP qw(
     is_ipv6
 );
 use Const::Fast;
-use List::MoreUtils qw(
-    all
-);
 use List::Util qw(
+    all
     shuffle
 );
 use Params::Util qw(


### PR DESCRIPTION
List::MoreUtils is only being used in one place for the 'all' function, which is already exportable from the version of List::Util required for this distribution.