### PR TITLE
Do not update default variable ($_) value in Kafka::IO->_connect

### DIFF
--- a/lib/Kafka/IO.pm
+++ b/lib/Kafka/IO.pm
@@ -644,7 +644,7 @@ sub _connect {
     socket( my $connection, $self->{pf}, SOCK_STREAM, scalar getprotobyname( 'tcp' ) ) or die( "socket: $!\n" );
 
     # Set autoflushing.
-    $_ = select( $connection ); $| = 1; select $_;
+    my $file_handle = select( $connection ); $| = 1; select $file_handle;
 
     # Set FD_CLOEXEC.
     my $flags = fcntl( $connection, F_GETFL, 0 ) or die "fcntl: $!\n";


### PR DESCRIPTION
Method `Kafka::IO->_connect()` updates `$_` variable. Its new value (e.g. ``main::STDOUT``) is propagated to it callers by `catch` of `Try::Tiny` which leads to an interesting failure when the code that calls Kafka library uses `$_` after the call.